### PR TITLE
Create settings menu

### DIFF
--- a/src/client/app/src/main/java/com/example/ravengamingnews/MainActivity.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/MainActivity.kt
@@ -4,8 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.rememberNavController
+import com.example.ravengamingnews.ui.ModalDrawerSheetPR
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
 
 class MainActivity : ComponentActivity() {
@@ -14,7 +19,17 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             RavenGamingNewsTheme {
-                TempAppScreen()
+                val navController = rememberNavController()
+                val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+                ModalNavigationDrawer(
+                    drawerState = drawerState,
+                    drawerContent = { ModalDrawerSheetPR(
+                        navController = navController,
+                        drawerState = drawerState,
+                    ) },
+                ) {
+                    TempAppScreen(navController)
+                }
             }
         }
     }
@@ -24,6 +39,15 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun GreetingPreview() {
     RavenGamingNewsTheme {
-        TempAppScreen()
+        val navController = rememberNavController()
+        val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+        ModalNavigationDrawer(
+            drawerContent = { ModalDrawerSheetPR(
+                navController = navController,
+                drawerState = drawerState,
+            ) },
+        ) {
+            TempAppScreen(navController)
+        }
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/TempNavScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/TempNavScreen.kt
@@ -1,6 +1,9 @@
 package com.example.ravengamingnews
 
 import androidx.annotation.StringRes
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -17,7 +20,6 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
 import com.example.ravengamingnews.ui.CreateAccountScreen
 import com.example.ravengamingnews.ui.EditAccountScreen
 import com.example.ravengamingnews.ui.FeedScreen
@@ -60,7 +62,7 @@ fun TempAppBar(
 
 @Composable
 fun TempAppScreen(
-    navController: NavHostController = rememberNavController()
+    navController: NavHostController
 ) {
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentScreen = TempNavScreen.valueOf(backStackEntry?.destination?.route ?: TempNavScreen.Feed.name)
@@ -72,7 +74,9 @@ fun TempAppScreen(
         NavHost(
             navController = navController,
             startDestination = TempNavScreen.TempRoute.name,
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.padding(innerPadding),
+            enterTransition = { fadeIn(animationSpec = tween(500)) },
+            exitTransition = { fadeOut(animationSpec = tween(500)) }
         ) {
             composable(route = TempNavScreen.TempRoute.name) {
                 TempRouteScreen(

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsScreen.kt
@@ -1,13 +1,120 @@
 package com.example.ravengamingnews.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import com.example.ravengamingnews.R
+import com.example.ravengamingnews.TempNavScreen
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
+import kotlinx.coroutines.launch
+
+@Composable
+fun ModalDrawerSheetPR(
+    navController: NavHostController,
+    drawerState: DrawerState,
+    modifier: Modifier = Modifier
+)
+{
+    val scope = rememberCoroutineScope()
+    ModalDrawerSheet(
+        drawerContainerColor = MaterialTheme.colorScheme.primaryContainer,
+        drawerShape = RectangleShape,
+    )
+    {
+        Column(
+            modifier = modifier.fillMaxWidth(.75f)
+        ) {
+            Surface(
+                shadowElevation = 16.dp,
+                color = MaterialTheme.colorScheme.primaryContainer,
+                modifier = modifier
+                    .height(64.dp)
+                    .fillMaxWidth()
+            ) {
+                Text(
+                    text = stringResource(R.string.settings),
+                    style = MaterialTheme.typography.headlineLarge,
+                    modifier = modifier.padding(16.dp)
+                )
+            }
+        }
+        Spacer(modifier.height(48.dp))
+        Column(
+            modifier = modifier.padding(start = 16.dp, top = 2.dp, bottom = 2.dp)
+        ) {
+            // Account
+            TextButton(
+                onClick = {
+                    scope.launch {
+                        drawerState.close()
+                    }
+                    navController.navigate(TempNavScreen.EditAccount.name)
+                },
+                modifier = modifier,
+            ) {
+                Text(
+                    text = stringResource(R.string.account),
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+            // Filters
+            TextButton(
+                onClick = {},
+                modifier = modifier,
+            ) {
+                Text(
+                    text = stringResource(R.string.filters),
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+            // Notifications
+            TextButton(
+                onClick = {},
+                modifier = modifier,
+            ) {
+                Text(
+                    text = stringResource(R.string.notifications),
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+            // Saved
+            TextButton(
+                onClick = {},
+                modifier = modifier,
+            ) {
+                Text(
+                    text = stringResource(R.string.saved),
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+        }
+    }
+}
 
 @Composable
 fun SettingsScreen(
@@ -27,5 +134,26 @@ fun SettingsScreen(
 fun SettingsScreenPreview() {
     RavenGamingNewsTheme {
         SettingsScreen()
+    }
+}
+
+@Preview
+@Composable
+fun ModalDrawerSheetPreview() {
+    RavenGamingNewsTheme {
+        val navController = rememberNavController()
+        val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+        ModalNavigationDrawer(
+            drawerContent = {
+                ModalDrawerSheetPR(
+                    navController = navController,
+                    drawerState = drawerState,
+                )
+            },
+        ) {
+            Scaffold { innerPadding ->
+                SettingsScreen(Modifier.padding(innerPadding))
+            }
+        }
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsScreen.kt
@@ -1,7 +1,10 @@
 package com.example.ravengamingnews.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -11,13 +14,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,89 +32,103 @@ import com.example.ravengamingnews.R
 import com.example.ravengamingnews.TempNavScreen
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
 import kotlinx.coroutines.launch
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.statusBars
 
 @Composable
 fun ModalDrawerSheetPR(
     navController: NavHostController,
     drawerState: DrawerState,
     modifier: Modifier = Modifier
-)
-{
+) {
     val scope = rememberCoroutineScope()
     ModalDrawerSheet(
         drawerContainerColor = MaterialTheme.colorScheme.primaryContainer,
         drawerShape = RectangleShape,
-    )
-    {
+    ) {
         Column(
             modifier = modifier.fillMaxWidth(.75f)
         ) {
-            Surface(
-                shadowElevation = 16.dp,
-                color = MaterialTheme.colorScheme.primaryContainer,
-                modifier = modifier
-                    .height(64.dp)
+            // Header styled as TopAppBar, no elevation, with divider at bottom
+            Column(
+                modifier = Modifier
                     .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .height(64.dp)
+                    .background(MaterialTheme.colorScheme.primaryContainer)
             ) {
                 Text(
                     text = stringResource(R.string.settings),
                     style = MaterialTheme.typography.headlineLarge,
-                    modifier = modifier.padding(16.dp)
+                    modifier = Modifier.padding(16.dp)
                 )
             }
-        }
-        Spacer(modifier.height(48.dp))
-        Column(
-            modifier = modifier.padding(start = 16.dp, top = 2.dp, bottom = 2.dp)
-        ) {
-            // Account
-            TextButton(
-                onClick = {
-                    scope.launch {
-                        drawerState.close()
-                    }
-                    navController.navigate(TempNavScreen.EditAccount.name)
-                },
-                modifier = modifier,
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(16.dp)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Black.copy(alpha = 0.18f),
+                                Color.Transparent
+                            )
+                        )
+                    )
+            )
+            Spacer(modifier.height(48.dp))
+            Column(
+                modifier = modifier.padding(start = 16.dp, top = 2.dp, bottom = 2.dp)
             ) {
-                Text(
-                    text = stringResource(R.string.account),
-                    style = MaterialTheme.typography.headlineLarge,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-            // Filters
-            TextButton(
-                onClick = {},
-                modifier = modifier,
-            ) {
-                Text(
-                    text = stringResource(R.string.filters),
-                    style = MaterialTheme.typography.headlineLarge,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-            // Notifications
-            TextButton(
-                onClick = {},
-                modifier = modifier,
-            ) {
-                Text(
-                    text = stringResource(R.string.notifications),
-                    style = MaterialTheme.typography.headlineLarge,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            }
-            // Saved
-            TextButton(
-                onClick = {},
-                modifier = modifier,
-            ) {
-                Text(
-                    text = stringResource(R.string.saved),
-                    style = MaterialTheme.typography.headlineLarge,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
+                // Account
+                TextButton(
+                    onClick = {
+                        scope.launch {
+                            drawerState.close()
+                        }
+                        navController.navigate(TempNavScreen.EditAccount.name)
+                    },
+                    modifier = modifier,
+                ) {
+                    Text(
+                        text = stringResource(R.string.account),
+                        style = MaterialTheme.typography.headlineLarge,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+                // Filters
+                TextButton(
+                    onClick = {},
+                    modifier = modifier,
+                ) {
+                    Text(
+                        text = stringResource(R.string.filters),
+                        style = MaterialTheme.typography.headlineLarge,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+                // Notifications
+                TextButton(
+                    onClick = {},
+                    modifier = modifier,
+                ) {
+                    Text(
+                        text = stringResource(R.string.notifications),
+                        style = MaterialTheme.typography.headlineLarge,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+                // Saved
+                TextButton(
+                    onClick = {},
+                    modifier = modifier,
+                ) {
+                    Text(
+                        text = stringResource(R.string.saved),
+                        style = MaterialTheme.typography.headlineLarge,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
             }
         }
     }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/components/CommonUi.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/components/CommonUi.kt
@@ -151,6 +151,7 @@ fun TextOnlyButtonPR(
         )
     }
 }
+
 @Composable
 fun LogoImagePR(modifier: Modifier = Modifier){
     val image = painterResource(R.drawable.patch_raven_logo_ver_3_orange)

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/theme/Theme.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/theme/Theme.kt
@@ -24,6 +24,7 @@ private val DarkColorScheme = darkColorScheme(
     primary = Orange,
     primaryContainer = DarkPurple,
     onPrimary = Color.White,
+    onPrimaryContainer = Gray,
     onSurface = Gray,
     onBackground = Gray,
     secondary = Gray,

--- a/src/client/app/src/main/res/values/strings.xml
+++ b/src/client/app/src/main/res/values/strings.xml
@@ -10,4 +10,8 @@
     <string name="error_invalid_email">INVALID EMAIL.</string>
     <string name="password">PASSWORD</string>
     <string name="dont_have_account_sign_up">Don\'t have an account?</string>
+    <string name="account">Account</string>
+    <string name="filters">Filters</string>
+    <string name="notifications">Notifications</string>
+    <string name="saved">Saved</string>
 </resources>


### PR DESCRIPTION
The menu slides out by swiping left to right.

Clicking Account will take you to the edit account page. Close the menu.
Other buttons are not hooked up yet.

Created a 2nd Trello task for the bottom half of this menu.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e5f2b4d0-834d-4dc1-9469-b896829d5718" />

---
Edit:  found a way to make the ahdow look better because the elevation was causing a slight shadow at the top:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2371063c-0ba1-4cb2-8452-f845cd9e44b7" />

