### PR TITLE
Finishing settings menu bottom section

### DIFF
--- a/src/client/app/src/main/java/com/example/ravengamingnews/MainActivity.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
-import com.example.ravengamingnews.ui.ModalDrawerSheetPR
+import com.example.ravengamingnews.ui.SettingsDrawer
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
 
 class MainActivity : ComponentActivity() {
@@ -23,7 +23,7 @@ class MainActivity : ComponentActivity() {
                 val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
                 ModalNavigationDrawer(
                     drawerState = drawerState,
-                    drawerContent = { ModalDrawerSheetPR(
+                    drawerContent = { SettingsDrawer(
                         navController = navController,
                         drawerState = drawerState,
                     ) },
@@ -42,7 +42,7 @@ fun GreetingPreview() {
         val navController = rememberNavController()
         val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
         ModalNavigationDrawer(
-            drawerContent = { ModalDrawerSheetPR(
+            drawerContent = { SettingsDrawer(
                 navController = navController,
                 drawerState = drawerState,
             ) },

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsDrawer.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsDrawer.kt
@@ -1,0 +1,208 @@
+package com.example.ravengamingnews.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.ravengamingnews.R
+import com.example.ravengamingnews.TempNavScreen
+import com.example.ravengamingnews.ui.components.ButtonPR
+import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
+import kotlinx.coroutines.launch
+
+@Composable
+fun SettingsDrawer(
+    navController: NavHostController,
+    drawerState: DrawerState,
+    modifier: Modifier = Modifier
+) {
+    // Temporary, replace with real login state
+    val isLoggedIn = false
+    ModalDrawerSheet(
+        drawerContainerColor = MaterialTheme.colorScheme.primaryContainer,
+        drawerShape = RectangleShape,
+    ) {
+        Column(
+            modifier = modifier.fillMaxWidth(.75f)
+        ) {
+            DrawerHeader()
+            MainSettingsDrawerContent(
+                navController = navController,
+                drawerState = drawerState,
+                modifier = modifier,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            BottomDrawerSection(
+                navController = navController,
+                drawerState = drawerState,
+                isLoggedIn = isLoggedIn,
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun DrawerHeader() {
+    // Header styled as TopAppBar, no elevation, with divider at bottom
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .height(64.dp)
+            .background(MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Text(
+            text = stringResource(R.string.settings),
+            style = MaterialTheme.typography.headlineLarge,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(16.dp)
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(
+                        Color.Black.copy(alpha = 0.18f),
+                        Color.Transparent
+                    )
+                )
+            )
+    )
+    Spacer(Modifier.height(48.dp))
+}
+
+@Composable
+private fun MainSettingsDrawerContent(
+    navController: NavHostController,
+    drawerState: DrawerState,
+    modifier: Modifier = Modifier
+) {
+    val scope = rememberCoroutineScope()
+    Column(
+        modifier = modifier.padding(start = 16.dp, top = 2.dp, bottom = 2.dp)
+    ) {
+        SettingsButton(
+            text = stringResource(R.string.account),
+            onClick = {
+                scope.launch { drawerState.close() }
+                navController.navigate(TempNavScreen.EditAccount.name)
+            }
+        )
+        SettingsButton(
+            text = stringResource(R.string.filters),
+            onClick = {}
+        )
+        SettingsButton(
+            text = stringResource(R.string.notifications),
+            onClick = {}
+        )
+        SettingsButton(
+            text = stringResource(R.string.saved),
+            onClick = {}
+        )
+    }
+}
+
+@Composable
+private fun BottomDrawerSection(
+    navController: NavHostController,
+    drawerState: DrawerState,
+    @Suppress("SameParameterValue") isLoggedIn: Boolean, // Remove warning suppression when login state is dynamic
+    modifier: Modifier = Modifier
+) {
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = modifier.padding(start = 16.dp, top = 2.dp, bottom = 32.dp)
+    ) {
+        SettingsButton(
+            text = stringResource(R.string.support).uppercase(),
+            style = MaterialTheme.typography.titleLarge,
+            onClick = {}
+        )
+        SettingsButton(
+            text = stringResource(R.string.about).uppercase(),
+            style = MaterialTheme.typography.titleLarge,
+            onClick = {}
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+
+        val buttonText = if (isLoggedIn) stringResource(R.string.sign_out) else stringResource(R.string.login)
+        ButtonPR(
+            text = buttonText,
+            onClick = {
+                scope.launch { drawerState.close() }
+                navController.navigate(TempNavScreen.Login.name)
+            },
+            modifier = Modifier
+                .padding(16.dp, end = 32.dp)
+                .fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun SettingsButton(
+    text: String,
+    onClick: () -> Unit,
+    style: TextStyle = MaterialTheme.typography.headlineLarge
+) {
+    TextButton(onClick = onClick) {
+        Text(
+            text = text,
+            style = style,
+            color = MaterialTheme.colorScheme.onPrimaryContainer
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SettingsDrawerPreview() {
+    RavenGamingNewsTheme {
+        val navController = rememberNavController()
+        val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+        ModalNavigationDrawer(
+            drawerContent = {
+                SettingsDrawer(
+                    navController = navController,
+                    drawerState = drawerState,
+                )
+            },
+        ) {
+            Scaffold { innerPadding ->
+                SettingsScreen(Modifier.padding(innerPadding))
+            }
+        }
+    }
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsScreen.kt
@@ -1,138 +1,13 @@
 package com.example.ravengamingnews.ui
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DrawerState
-import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalDrawerSheet
-import androidx.compose.material3.ModalNavigationDrawer
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.example.ravengamingnews.R
-import com.example.ravengamingnews.TempNavScreen
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
-import kotlinx.coroutines.launch
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.statusBars
-
-@Composable
-fun ModalDrawerSheetPR(
-    navController: NavHostController,
-    drawerState: DrawerState,
-    modifier: Modifier = Modifier
-) {
-    val scope = rememberCoroutineScope()
-    ModalDrawerSheet(
-        drawerContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        drawerShape = RectangleShape,
-    ) {
-        Column(
-            modifier = modifier.fillMaxWidth(.75f)
-        ) {
-            // Header styled as TopAppBar, no elevation, with divider at bottom
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .windowInsetsPadding(WindowInsets.statusBars)
-                    .height(64.dp)
-                    .background(MaterialTheme.colorScheme.primaryContainer)
-            ) {
-                Text(
-                    text = stringResource(R.string.settings),
-                    style = MaterialTheme.typography.headlineLarge,
-                    modifier = Modifier.padding(16.dp)
-                )
-            }
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(16.dp)
-                    .background(
-                        Brush.verticalGradient(
-                            colors = listOf(
-                                Color.Black.copy(alpha = 0.18f),
-                                Color.Transparent
-                            )
-                        )
-                    )
-            )
-            Spacer(modifier.height(48.dp))
-            Column(
-                modifier = modifier.padding(start = 16.dp, top = 2.dp, bottom = 2.dp)
-            ) {
-                // Account
-                TextButton(
-                    onClick = {
-                        scope.launch {
-                            drawerState.close()
-                        }
-                        navController.navigate(TempNavScreen.EditAccount.name)
-                    },
-                    modifier = modifier,
-                ) {
-                    Text(
-                        text = stringResource(R.string.account),
-                        style = MaterialTheme.typography.headlineLarge,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-                // Filters
-                TextButton(
-                    onClick = {},
-                    modifier = modifier,
-                ) {
-                    Text(
-                        text = stringResource(R.string.filters),
-                        style = MaterialTheme.typography.headlineLarge,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-                // Notifications
-                TextButton(
-                    onClick = {},
-                    modifier = modifier,
-                ) {
-                    Text(
-                        text = stringResource(R.string.notifications),
-                        style = MaterialTheme.typography.headlineLarge,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-                // Saved
-                TextButton(
-                    onClick = {},
-                    modifier = modifier,
-                ) {
-                    Text(
-                        text = stringResource(R.string.saved),
-                        style = MaterialTheme.typography.headlineLarge,
-                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                }
-            }
-        }
-    }
-}
 
 @Composable
 fun SettingsScreen(
@@ -152,26 +27,5 @@ fun SettingsScreen(
 fun SettingsScreenPreview() {
     RavenGamingNewsTheme {
         SettingsScreen()
-    }
-}
-
-@Preview
-@Composable
-fun ModalDrawerSheetPreview() {
-    RavenGamingNewsTheme {
-        val navController = rememberNavController()
-        val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
-        ModalNavigationDrawer(
-            drawerContent = {
-                ModalDrawerSheetPR(
-                    navController = navController,
-                    drawerState = drawerState,
-                )
-            },
-        ) {
-            Scaffold { innerPadding ->
-                SettingsScreen(Modifier.padding(innerPadding))
-            }
-        }
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/theme/Type.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/theme/Type.kt
@@ -79,7 +79,7 @@ val Typography = Typography(
         letterSpacing = 0.5.sp
     ),
     titleLarge = TextStyle(
-        fontFamily = BigNoodle,
+        fontFamily = FontFamily.Default,
         fontStyle = FontStyle.Italic,
         fontSize = 24.sp,
         lineHeight = 32.sp,

--- a/src/client/app/src/main/res/values/strings.xml
+++ b/src/client/app/src/main/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="filters">Filters</string>
     <string name="notifications">Notifications</string>
     <string name="saved">Saved</string>
+    <string name="about">About</string>
+    <string name="support">Support</string>
+    <string name="sign_out">Sign Out</string>
 </resources>


### PR DESCRIPTION
moved the drawer code to a new file separate from the other screen, which probably will be deleted at some point or repurposed.

Broke the code up a bit after getting it all working to refactor into smaller easier to easier-to-understand chunks.

The only two buttons on the menu that do anything at this time are the Account and Login buttons.  Also, the Login Button changes to Sign Out if they are logged in.  We do not have any real "logged in" state yet, so this is hardcoded to be false for now.

<img width="400" alt="settings drawer" src="https://github.com/user-attachments/assets/e2de8feb-fbe3-402f-b73d-a6e741cde0f2" />
