### PR TITLE
Add dependency injection

### DIFF
--- a/src/client/app/build.gradle.kts
+++ b/src/client/app/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
 }
 
 android {
@@ -57,6 +59,9 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.runtime.ktx)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.hilt.android)
+    implementation(libs.hilt.navigation.compose)
+    ksp(libs.hilt.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/src/client/app/src/main/AndroidManifest.xml
+++ b/src/client/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".PatchRavenApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/src/client/app/src/main/java/com/example/ravengamingnews/AuthViewModel.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/AuthViewModel.kt
@@ -2,6 +2,8 @@ package com.example.ravengamingnews
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,7 +15,8 @@ data class AuthState(
     val isLoading: Boolean = false,
 )
 
-class AuthViewModel : ViewModel() {
+@HiltViewModel
+class AuthViewModel @Inject constructor(): ViewModel() {
     private val _authState = MutableStateFlow(AuthState())
     val authState: StateFlow<AuthState> = _authState.asStateFlow()
 

--- a/src/client/app/src/main/java/com/example/ravengamingnews/MainActivity.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -27,7 +28,9 @@ import com.example.ravengamingnews.ui.NoAccountScreen
 import com.example.ravengamingnews.ui.LoginScreen
 import com.example.ravengamingnews.ui.SettingsDrawer
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val authViewModel: AuthViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,10 +44,10 @@ class MainActivity : ComponentActivity() {
                         LoadingScreen()
                     }
                     authState.isLoggedIn || authState.continuedAsGuest -> {
-                        MainApp(authViewModel)
+                        MainApp()
                     }
                     else -> {
-                        LoginFlow(authViewModel)
+                        LoginFlow()
                     }
                 }
             }
@@ -53,7 +56,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun MainApp(authViewModel: AuthViewModel) {
+fun MainApp() {
     val navController = rememberNavController()
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 
@@ -63,7 +66,6 @@ fun MainApp(authViewModel: AuthViewModel) {
             SettingsDrawer(
                 navController = navController,
                 drawerState = drawerState,
-                authViewModel = authViewModel
             )
         },
     ) {
@@ -72,8 +74,9 @@ fun MainApp(authViewModel: AuthViewModel) {
 }
 
 @Composable
-fun LoginFlow(authViewModel: AuthViewModel) {
+fun LoginFlow() {
     val navController = rememberNavController()
+    val authViewModel: AuthViewModel = hiltViewModel()
 
     Scaffold { innerPadding ->
         NavHost(
@@ -114,15 +117,13 @@ fun GreetingPreview() {
     RavenGamingNewsTheme {
         val navController = rememberNavController()
         val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
-        val authViewModel = AuthViewModel() // Replace with a real instance
         ModalNavigationDrawer(
             drawerContent = { SettingsDrawer(
                 navController = navController,
                 drawerState = drawerState,
-                authViewModel = authViewModel,
             ) },
         ) {
-            MainApp(authViewModel = authViewModel)
+            MainApp()
         }
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/PatchRavenApplication.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/PatchRavenApplication.kt
@@ -1,0 +1,9 @@
+package com.example.ravengamingnews
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class PatchRavenApplication : Application() {
+    // Application-wide initialization can go here if needed
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsDrawer.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsDrawer.kt
@@ -31,11 +31,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.example.ravengamingnews.AuthViewModel
-import com.example.ravengamingnews.R
 import com.example.ravengamingnews.HomeScreen
+import com.example.ravengamingnews.R
 import com.example.ravengamingnews.ui.components.ButtonPR
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
 import kotlinx.coroutines.launch
@@ -44,7 +45,6 @@ import kotlinx.coroutines.launch
 fun SettingsDrawer(
     navController: NavHostController,
     drawerState: DrawerState,
-    authViewModel: AuthViewModel,
     modifier: Modifier = Modifier,
 ) {
     ModalDrawerSheet(
@@ -63,7 +63,6 @@ fun SettingsDrawer(
             Spacer(modifier = Modifier.weight(1f))
             BottomDrawerSection(
                 drawerState = drawerState,
-                authViewModel = authViewModel,
                 modifier = modifier
             )
         }
@@ -137,9 +136,9 @@ private fun MainSettingsDrawerContent(
 @Composable
 private fun BottomDrawerSection(
     drawerState: DrawerState,
-    authViewModel: AuthViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
+    val authViewModel: AuthViewModel = hiltViewModel()
     val authState by authViewModel.authState.collectAsState()
     val scope = rememberCoroutineScope()
 
@@ -194,13 +193,11 @@ fun SettingsDrawerPreview() {
     RavenGamingNewsTheme {
         val navController = rememberNavController()
         val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
-        val authViewModel = AuthViewModel() // Create a real instance, not an object extension
         ModalNavigationDrawer(
             drawerContent = {
                 SettingsDrawer(
                     navController = navController,
                     drawerState = drawerState,
-                    authViewModel = authViewModel,
                 )
             },
         ) {

--- a/src/client/build.gradle.kts
+++ b/src/client/build.gradle.kts
@@ -3,4 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.hilt) apply false
 }

--- a/src/client/gradle/libs.versions.toml
+++ b/src/client/gradle/libs.versions.toml
@@ -1,15 +1,16 @@
 [versions]
 agp = "8.12.2"
-kotlin = "2.2.0"
-coreKtx = "1.16.0"
+kotlin = "2.2.10"
+coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-lifecycleRuntimeKtx = "2.9.2"
+lifecycleRuntimeKtx = "2.9.3"
 activityCompose = "1.10.1"
-composeBom = "2025.07.00"
+composeBom = "2025.08.01"
 navigationRuntimeKtx = "2.9.3"
 navigationCompose = "2.9.3"
+hiltVersion = "2.57.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,9 +29,14 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hiltVersion" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltVersion" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hiltVersion" }
+ksp = { id = "com.google.devtools.ksp", version = "2.2.10-2.0.2" }
 


### PR DESCRIPTION
No longer have to pass the viewModel or state from the view model down through the composables.

One thing that bugged me with composeables was having to pass state through many layers.  I had a task in Trello to research dependency injection:

https://trello.com/c/GnBgBmRC/4-research-dependency-injection-in-kotlin

This adds Hilt, which is the preferred way to handle DI in Kotlin / Jetpack Compose.
It took a bit of playing around to get it to finally compile and work.
I referenced many of the links in the Research Task linked above.

I then created a Trello task to add DI and use it for Auth State instead of passing the state down through everything.
https://trello.com/c/tlszGV1F/32-add-hilt-to-project-for-dependency-injection

This PR cleans this up and you can see now that AuthStateViewModel is no longer passed down through any parameters.

The Settings Bottom Drawer Section just uses `hiltViewModel()` to get the scoped instance of the auth state and use it.

It seems to be working great for me.

I will next work on how to do the same for navigation with the `navHostController` and/or DrawerState.