### PR TITLE
Alternate Top App Bar for settings pages

### DIFF
--- a/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.Icon
@@ -17,6 +18,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults.mediumTopAppBarColors
 import androidx.compose.runtime.Composable
@@ -25,6 +27,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
@@ -43,6 +46,7 @@ import com.example.ravengamingnews.ui.SavedScreen
 import com.example.ravengamingnews.ui.SupportScreen
 import com.example.ravengamingnews.ui.components.LogoImagePR
 import com.example.ravengamingnews.ui.components.TopAppBarButtonPR
+import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
 import kotlinx.coroutines.launch
 
 /**
@@ -123,20 +127,80 @@ fun TopAppBarPR(
 }
 
 @Composable
+fun SettingsTopAppBar(
+    modifier: Modifier = Modifier,
+    title: String,
+    onBackClicked: () -> Unit,
+) {
+    Surface(shadowElevation = 16.dp) {
+        TopAppBar(
+            title = {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                ) {
+                    IconButton(onClick = onBackClicked) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
+            },
+            colors = mediumTopAppBarColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
 fun HomeScreen(
     drawerState: DrawerState,
 ) {
     val navController = rememberNavController()
     val navigationViewModel: NavigationViewModel = hiltViewModel()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route ?: HomeScreen.Feed.name
+
+    // Define main screen routes (anything else will be considered settings-related)
+    val mainScreenRoutes = listOf(
+        HomeScreen.Feed.name,
+        // "All",
+        // "Browse",
+        // "Article Detail Screen", etc...
+    )
+    // Check if current route is a main screen
+    val isMainScreen = currentRoute in mainScreenRoutes
 
     // Set NavController in NavigationViewModel
     navigationViewModel.setNavController(navController)
 
     Scaffold(
         topBar = {
-            TopAppBarPR(
-                drawerState = drawerState
-            )
+            if (isMainScreen) {
+                TopAppBarPR(
+                    drawerState = drawerState
+                )
+            } else {
+                SettingsTopAppBar(
+                    title = stringResource(
+                        HomeScreen.valueOf(
+                            backStackEntry?.destination?.route
+                                ?: HomeScreen.Feed.name
+                        ).title
+                    ),
+                    onBackClicked = { navigationViewModel.navigateUp() }
+                )
+            }
         }
     ) { innerPadding ->
         NavHost(
@@ -168,5 +232,36 @@ fun HomeScreen(
                 NavType.StringType})) {backStackEntry -> val articleId = backStackEntry.arguments?.getString("articleId")
             ArticlePage(articleId = articleId)}
         }
+    }
+}
+
+@Preview
+@Composable
+fun SettingsTopAppBarPreview() {
+    RavenGamingNewsTheme {
+        SettingsTopAppBar(
+            title = stringResource(R.string.edit_account),
+            onBackClicked = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun TopAppBarPreview() {
+    RavenGamingNewsTheme {
+        TopAppBarPR(
+            drawerState = DrawerState(initialValue = androidx.compose.material3.DrawerValue.Closed)
+        )
+    }
+}
+
+@Preview
+@Composable
+fun HomeScreenPreview() {
+    RavenGamingNewsTheme {
+        HomeScreen(
+            drawerState = DrawerState(initialValue = androidx.compose.material3.DrawerValue.Closed)
+        )
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/navigation/AppRoutes.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/navigation/AppRoutes.kt
@@ -1,0 +1,34 @@
+package com.example.ravengamingnews.navigation
+
+import com.example.ravengamingnews.R
+
+object AppRoutes {
+    // Home section routes
+    const val HOME_FEED = "feed"
+    const val HOME_BROWSE = "browse"
+    const val HOME_ALL = "all"
+    const val ARTICLE_DETAILS = "article/{articleId}"
+
+    // Settings section routes
+    const val SETTINGS_EDIT_ACCOUNT = "settings/edit_account"
+    const val SETTINGS_FILTERS = "settings/filters"
+    const val SETTINGS_SAVED = "settings/saved"
+    const val SETTINGS_SUPPORT = "settings/support"
+    const val SETTINGS_ABOUT = "settings/about"
+
+    fun isSettingsRoute(route: String): Boolean {
+        return route.startsWith("settings/")
+    }
+
+    fun getTitleResId(route: String): Int {
+        return when (route) {
+            SETTINGS_EDIT_ACCOUNT -> R.string.edit_account
+            SETTINGS_FILTERS -> R.string.filters
+            SETTINGS_SAVED -> R.string.saved
+            SETTINGS_SUPPORT -> R.string.support
+            SETTINGS_ABOUT -> R.string.about
+            else -> R.string.app_name // Fallback
+        }
+    }
+}
+

--- a/src/client/app/src/main/java/com/example/ravengamingnews/navigation/NavigationViewModel.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/navigation/NavigationViewModel.kt
@@ -34,7 +34,7 @@ class NavigationViewModel @Inject constructor() : ViewModel() {
         _navController?.popBackStack()
     }
 
-    fun markClicked(articleId: Int){
+    fun markClicked(articleId: Int) {
         _clickedArticles[articleId] = true
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticlePage.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticlePage.kt
@@ -10,24 +10,25 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.example.ravengamingnews.data.TempDataSource
 
 @Composable
-fun ArticlePage(articleId: String?){
+fun ArticlePage(articleId: String?) {
     val id = articleId?.toIntOrNull()
     val article = TempDataSource.fakeArticleList.find { it.id == id }
 
-    if(article != null){
-        Column(modifier = Modifier.padding(16.dp)){
+    if (article != null) {
+        Column(modifier = Modifier.padding(16.dp)) {
             Spacer(Modifier.height(16.dp))
             Text(article.title, style = MaterialTheme.typography.headlineLarge)
             Spacer(Modifier.height(16.dp))
-            Row{ Text(article.author,
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary)
+            Row {
+                Text(
+                    article.author,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
                 Spacer(Modifier.width(8.dp))
                 Text("-")
                 Spacer(Modifier.width(8.dp))
@@ -37,5 +38,7 @@ fun ArticlePage(articleId: String?){
             Text(article.content)
 
         }
-    } else {Text("Article not found", modifier = Modifier.padding(8.dp))}
+    } else {
+        Text("Article not found", modifier = Modifier.padding(8.dp))
+    }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/FeedScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/FeedScreen.kt
@@ -1,9 +1,5 @@
 package com.example.ravengamingnews.ui
 
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -20,26 +16,15 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHost
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import com.example.ravengamingnews.HomeScreen
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.ravengamingnews.data.TempDataSource
+import com.example.ravengamingnews.navigation.AppRoutes
 import com.example.ravengamingnews.navigation.NavigationViewModel
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
-
 
 
 @Composable
@@ -50,8 +35,8 @@ fun ArticleCard(
     articleDate: String,
     wasClicked: Boolean,
     onClick: () -> Unit
-){
-    val articleCardColor = if(wasClicked) MaterialTheme.colorScheme.tertiary
+) {
+    val articleCardColor = if (wasClicked) MaterialTheme.colorScheme.tertiary
     else MaterialTheme.colorScheme.primaryContainer
     Card(
         modifier = Modifier
@@ -66,11 +51,11 @@ fun ArticleCard(
             .cardColors(
                 containerColor = articleCardColor
             )
-    ){
+    ) {
         Column(
             modifier = Modifier
                 .padding(16.dp),
-        ){
+        ) {
             Text(
                 text = articleTitle,
                 style = MaterialTheme.typography.headlineLarge,
@@ -97,8 +82,8 @@ fun ArticleCard(
                 overflow = TextOverflow.Ellipsis
             )
             Spacer(
-                    modifier = Modifier.height(12.dp)
-                    )
+                modifier = Modifier.height(12.dp)
+            )
             Text(
                 text = articleDate,
                 style = MaterialTheme.typography.labelSmall,
@@ -110,39 +95,43 @@ fun ArticleCard(
 }
 
 @Composable
-fun FeedScreen(navigationViewModel: NavigationViewModel? = null
-){
-    val clickedArticles = navigationViewModel?.clickedArticles
-
+fun FeedScreen(
+    navigationViewModel: NavigationViewModel = hiltViewModel()
+) {
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .padding(8.dp),
         verticalArrangement = Arrangement
             .spacedBy(8.dp)
-    ){
-            items(TempDataSource.fakeArticleList) { item ->
-                val isClicked = navigationViewModel?.clickedArticles[item.id] == true
+    ) {
+        items(TempDataSource.fakeArticleList) { item ->
+            val isClicked = navigationViewModel.clickedArticles[item.id] == true
 
-                ArticleCard(
-                    item.title,
-                    item.author,
-                    item.summary,
-                    item.date,
-                    wasClicked = isClicked,
-                    onClick = {
-                       navigationViewModel?.markClicked(item.id)
-                        navigationViewModel?.navigateTo("article/${item.id}")
-                    }
-                )
-            }
+            ArticleCard(
+                item.title,
+                item.author,
+                item.summary,
+                item.date,
+                wasClicked = isClicked,
+                onClick = {
+                    navigationViewModel.markClicked(item.id)
+                    navigationViewModel.navigateTo(
+                        AppRoutes.ARTICLE_DETAILS.replace(
+                            "{articleId}",
+                            item.id.toString()
+                        )
+                    )
+                }
+            )
         }
     }
+}
 
 @Preview
 @Composable
 fun FeedScreenPreview() {
     RavenGamingNewsTheme {
-           FeedScreen()
+        FeedScreen()
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsDrawer.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/SettingsDrawer.kt
@@ -36,8 +36,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.ravengamingnews.AuthViewModel
-import com.example.ravengamingnews.HomeScreen
 import com.example.ravengamingnews.R
+import com.example.ravengamingnews.navigation.AppRoutes
 import com.example.ravengamingnews.navigation.NavigationViewModel
 import com.example.ravengamingnews.ui.components.ButtonPR
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
@@ -116,14 +116,14 @@ private fun MainSettingsDrawerContent(
             text = stringResource(R.string.account),
             onClick = {
                 scope.launch { drawerState.close() }
-                navigationViewModel.navigateTo(HomeScreen.EditAccount.name)
+                navigationViewModel.navigateTo(AppRoutes.SETTINGS_EDIT_ACCOUNT)
             }
         )
         SettingsButton(
             text = stringResource(R.string.filters),
             onClick = {
                 scope.launch { drawerState.close() }
-                navigationViewModel.navigateTo(HomeScreen.Filters.name)
+                navigationViewModel.navigateTo(AppRoutes.SETTINGS_FILTERS)
             }
         )
         SettingsButton(
@@ -141,7 +141,7 @@ private fun MainSettingsDrawerContent(
             text = stringResource(R.string.saved),
             onClick = {
                 scope.launch { drawerState.close() }
-                navigationViewModel.navigateTo(HomeScreen.Saved.name)
+                navigationViewModel.navigateTo(AppRoutes.SETTINGS_SAVED)
             }
         )
     }
@@ -165,7 +165,7 @@ private fun BottomDrawerSection(
             style = MaterialTheme.typography.titleLarge,
             onClick = {
                 scope.launch { drawerState.close() }
-                navigationViewModel.navigateTo(HomeScreen.Support.name)
+                navigationViewModel.navigateTo(AppRoutes.SETTINGS_SUPPORT)
             }
         )
         SettingsButton(
@@ -173,7 +173,7 @@ private fun BottomDrawerSection(
             style = MaterialTheme.typography.titleLarge,
             onClick = {
                 scope.launch { drawerState.close() }
-                navigationViewModel.navigateTo(HomeScreen.About.name)
+                navigationViewModel.navigateTo(AppRoutes.SETTINGS_ABOUT)
             }
         )
         Spacer(modifier = Modifier.height(24.dp))

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/components/CommonUi.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/components/CommonUi.kt
@@ -1,6 +1,5 @@
 package com.example.ravengamingnews.ui.components
 
-import android.view.Surface
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -16,22 +15,16 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults.mediumTopAppBarColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
@@ -41,8 +34,6 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.Alignment
-import androidx.navigation.NavHostController
 import com.example.ravengamingnews.R
 import com.example.ravengamingnews.ui.theme.CommonUiSize
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
@@ -72,10 +63,12 @@ fun OutlinedTextFieldPR(
     keyboardOptions: KeyboardOptions? = null,
     isPassword: Boolean = false
 ) {
-    Column(modifier = modifier
-        .fillMaxWidth()
-        .padding(vertical = 4.dp)
-        .padding(horizontal = 16.dp)) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .padding(horizontal = 16.dp)
+    ) {
         OutlinedTextField(
             value = value,
             singleLine = true,
@@ -162,7 +155,7 @@ fun TextOnlyButtonPR(
 }
 
 @Composable
-fun LogoImagePR(modifier: Modifier = Modifier){
+fun LogoImagePR(modifier: Modifier = Modifier) {
     val image = painterResource(R.drawable.patch_raven_logo_ver_3_orange)
 
     Image(
@@ -183,7 +176,7 @@ fun TopAppBarButtonPR(
         onClick = onClick,
         modifier = modifier
     ) {
-        Column(horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = text.uppercase(),
                 style = MaterialTheme.typography.headlineMedium,
@@ -209,10 +202,12 @@ fun TopAppBarButtonPR(
 fun OutlinedTextFieldPreview() {
     RavenGamingNewsTheme {
         Scaffold { innerPadding ->
-            Column(modifier = Modifier.padding(innerPadding)
-                .fillMaxSize(),
+            Column(
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize(),
                 verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
-                horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 LogoImagePR(
                     modifier = Modifier
@@ -254,13 +249,16 @@ fun OutlinedTextFieldPreview() {
                     onClick = { },
                     size = CommonUiSize.Large
                 )
-                Text(text = "Hello World",
+                Text(
+                    text = "Hello World",
                     style = MaterialTheme.typography.headlineSmall
                 )
-                Text(text = "Hello World",
+                Text(
+                    text = "Hello World",
                     style = MaterialTheme.typography.headlineMedium
                 )
-                Text(text = "Hello World",
+                Text(
+                    text = "Hello World",
                     style = MaterialTheme.typography.headlineLarge
                 )
                 Row {


### PR DESCRIPTION
> [!Note]
> All relevant changes are in HomeScreen.kt.
> The changes to CommonUI.kt were just removing unused imports and doing a "format code"

# Settings Top App Bar

It came to my attention in testing that the settings screens are meant to have their own top app bar.
I created an alternate top app bar for when the user is on a settings page.

## Steps to test

1. On the "Feed" page.
2. Open the menu
3. Click Edit Account
4. You'll see:
<img width="557" height="290" alt="image" src="https://github.com/user-attachments/assets/4c7be5e7-f11d-493a-9629-52bde5bde110" />

5. Click the Back button
6. Click the menu.
7. Click "About"
8. You'll see:
<img width="553" height="382" alt="image" src="https://github.com/user-attachments/assets/31d595c3-ef49-4db0-996c-0171ff82bc88" />

This app bar could be moved to Common UI and used for the "No Account" screen.
