### PR TITLE
Ordering articles descending

### DIFF
--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/repository/impl/ArticleRepositoryImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/repository/impl/ArticleRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.example.ravengamingnews.data.ArticleWithGameDto
 import com.example.ravengamingnews.data.ArticleRepository
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.query.Columns
+import io.github.jan.supabase.postgrest.query.Order
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -25,7 +26,11 @@ class ArticleRepositoryImpl @Inject constructor(
                             )
                         """
                     )
-                ).decodeList<ArticleWithGameDto>()
+                )
+                {
+                    order("date", Order.DESCENDING)
+                }
+                .decodeList<ArticleWithGameDto>()
             result
         }
     }


### PR DESCRIPTION
The previous PR accidentally targeted `main`
I reverted `main` back to the original version and reopened this to target `dev`

https://github.com/Cos229-239/2025_08_Team2/pull/38

<img width="554" height="669" alt="image" src="https://github.com/user-attachments/assets/4551b0dc-9baa-4973-a3ea-cc6e54eb0918" />
