### PR TITLE
Implementing topics differently

### DIFF
--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/ArticleDto.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/ArticleDto.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  * Data class representing a news article.
  */
 @Serializable
-data class ArticleWithGameDto(
+data class ArticleDto(
     @SerialName("id")
     val id: Int,
     @SerialName("created_at")
@@ -25,5 +25,5 @@ data class ArticleWithGameDto(
     @SerialName("game")
     val game: GameDto,
     @SerialName("topic")
-    val topic: String,
+    val topic: TopicEnum?,
 )

--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/ArticleDto.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/ArticleDto.kt
@@ -24,6 +24,11 @@ data class ArticleDto(
     val date: String,
     @SerialName("game")
     val game: GameDto,
+    /**
+     * The topic of the article, which can be null if not specified.
+     * See [TopicEnum] for possible values.
+     * Null values should be handled appropriately in the UI as undefined or uncategorized.
+     */
     @SerialName("topic")
     val topic: TopicEnum?,
 )

--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/ArticleRepository.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/ArticleRepository.kt
@@ -1,5 +1,5 @@
 package com.example.ravengamingnews.data
 
 interface ArticleRepository {
-    suspend fun getArticles(): List<ArticleWithGameDto>?
+    suspend fun getArticles(): List<ArticleDto>?
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/TopicEnum.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/TopicEnum.kt
@@ -1,0 +1,19 @@
+package com.example.ravengamingnews.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class TopicEnum {
+    @SerialName("Patch Notes")
+    PATCH_NOTES,
+
+    @SerialName("Game Updates")
+    GAME_UPDATES,
+
+    @SerialName("Cosmetics")
+    COSMETICS,
+
+    @SerialName("Game Modes")
+    GAME_MODES;
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/repository/impl/ArticleRepositoryImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/repository/impl/ArticleRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.example.ravengamingnews.data.repository.impl
 
-import com.example.ravengamingnews.data.ArticleWithGameDto
+import com.example.ravengamingnews.data.ArticleDto
 import com.example.ravengamingnews.data.ArticleRepository
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.query.Columns
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class ArticleRepositoryImpl @Inject constructor(
     private val postgrest: Postgrest
 ) : ArticleRepository {
-    override suspend fun getArticles(): List<ArticleWithGameDto> {
+    override suspend fun getArticles(): List<ArticleDto> {
         return withContext(Dispatchers.IO) {
             val result = postgrest.from("articles")
                 .select(
@@ -21,16 +21,15 @@ class ArticleRepositoryImpl @Inject constructor(
                             *,
                             game:games(
                                 id,
-                                name,
-                                created_at
+                                created_at,
+                                name
                             )
                         """
                     )
-                )
-                {
+                ) {
                     order("date", Order.DESCENDING)
                 }
-                .decodeList<ArticleWithGameDto>()
+                .decodeList<ArticleDto>()
             result
         }
     }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/model/Article.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/model/Article.kt
@@ -1,5 +1,6 @@
 package com.example.ravengamingnews.domain.model
 
+import com.example.ravengamingnews.data.TopicEnum
 import kotlin.time.Instant
 
 data class Article(
@@ -9,6 +10,8 @@ data class Article(
     val content: String,
     val author: String,
     val date: Instant,
-    val game: String,
-    val topic:String,
+    val gameId: Int,
+    val gameNameResId: Int, // Resource ID for localized game name
+    val topic: TopicEnum?,
+    val topicNameResId: Int?, // Resource ID for localized topic name
 )

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/GetArticlesUseCaseImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/GetArticlesUseCaseImpl.kt
@@ -33,6 +33,6 @@ class GetArticlesUseCaseImpl @Inject constructor(
         gameId = this.game.id,
         gameNameResId = ResourceMapper.getGameNameResourceId(this.game.id),
         topic = this.topic,
-        topicNameResId = this.topic?.let { ResourceMapper.getTopicNameResourceId(it) }
+        topicNameResId = ResourceMapper.getTopicNameResourceId(this.topic)
     )
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/GetArticlesUseCaseImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/GetArticlesUseCaseImpl.kt
@@ -1,9 +1,10 @@
 package com.example.ravengamingnews.domain.usecase.impl
 
 import com.example.ravengamingnews.data.ArticleRepository
-import com.example.ravengamingnews.data.ArticleWithGameDto
+import com.example.ravengamingnews.data.ArticleDto
 import com.example.ravengamingnews.domain.model.Article
 import com.example.ravengamingnews.domain.usecase.GetArticlesUseCase
+import com.example.ravengamingnews.util.ResourceMapper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -22,14 +23,16 @@ class GetArticlesUseCaseImpl @Inject constructor(
             } ?: GetArticlesUseCase.Output.Failure
         }
 
-    private fun ArticleWithGameDto.asDomainModel() = Article(
+    private fun ArticleDto.asDomainModel() = Article(
         id = this.id,
         title = this.title,
         summary = this.summary,
         content = this.content,
         author = this.author,
         date = Instant.Companion.parse(this.date),
-        game = this.game.name,
-        topic = this.topic
+        gameId = this.game.id,
+        gameNameResId = ResourceMapper.getGameNameResourceId(this.game.id),
+        topic = this.topic,
+        topicNameResId = this.topic?.let { ResourceMapper.getTopicNameResourceId(it) }
     )
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticlePage.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticlePage.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.ravengamingnews.ui.ArticleListViewModel
 import com.example.ravengamingnews.utils.toFormattedString
 
 @Composable

--- a/src/client/app/src/main/java/com/example/ravengamingnews/util/ResourceMapper.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/util/ResourceMapper.kt
@@ -26,8 +26,8 @@ object ResourceMapper {
      * @param topicId The topic ID from the API
      * @return The string resource ID for the localized topic name, or fallback if no mapping exists
      */
-    fun getTopicNameResourceId(topicId: TopicEnum?): Int {
-        return topicNameMap[topicId] ?: R.string.unknown_topic
+    fun getTopicNameResourceId(topicId: TopicEnum?): Int? {
+        return topicNameMap[topicId]
     }
 
     /**

--- a/src/client/app/src/main/java/com/example/ravengamingnews/util/ResourceMapper.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/util/ResourceMapper.kt
@@ -1,0 +1,57 @@
+package com.example.ravengamingnews.util
+
+import com.example.ravengamingnews.R
+import com.example.ravengamingnews.data.TopicEnum
+
+/**
+ * Utility class to map game and topic IDs to their corresponding string resource IDs.
+ * This enables proper localization of game and topic names without requiring
+ * the backend to handle localization.
+ */
+object ResourceMapper {
+
+    /**
+     * Maps a game ID to its corresponding string resource ID.
+     *
+     * @param gameId The game ID from the API
+     * @return The string resource ID for the localized game name, or fallback if no mapping exists
+     */
+    fun getGameNameResourceId(gameId: Int): Int {
+        return gameNameMap[gameId] ?: R.string.unknown_game
+    }
+
+    /**
+     * Maps a topic ID to its corresponding string resource ID.
+     *
+     * @param topicId The topic ID from the API
+     * @return The string resource ID for the localized topic name, or fallback if no mapping exists
+     */
+    fun getTopicNameResourceId(topicId: TopicEnum?): Int {
+        return topicNameMap[topicId] ?: R.string.unknown_topic
+    }
+
+    /**
+     * Map of game IDs to string resource IDs.
+     * Add entries here whenever a new game is added to the backend.
+     */
+    private val gameNameMap = mapOf(
+        1 to R.string.game_1,
+        2 to R.string.game_2,
+        3 to R.string.game_3,
+        4 to R.string.game_4,
+        5 to R.string.game_5
+        // Add more mappings as needed
+    )
+
+    /**
+     * Map of topic IDs to string resource IDs.
+     * Add entries here whenever a new topic is added to the backend.
+     */
+    private val topicNameMap = mapOf(
+        TopicEnum.PATCH_NOTES to R.string.topic_1,
+        TopicEnum.GAME_UPDATES to R.string.topic_2,
+        TopicEnum.COSMETICS to R.string.topic_3,
+        TopicEnum.GAME_MODES to R.string.topic_4,
+        // Add more mappings as needed
+    )
+}

--- a/src/client/app/src/main/res/values/strings.xml
+++ b/src/client/app/src/main/res/values/strings.xml
@@ -21,4 +21,21 @@
     <string name="continue_without_account">Continue Without Account</string>
     <string name="no_account_prompt">If you don\'t have an account, you can create a free account or you can browse the app without an account.\n\nBe aware browsing without an account will not sync your preferences across devices.</string>
     <string name="back_to_login">BACK TO LOGIN</string>
+
+    <!-- Game Names -->
+    <string name="game_1">League of Legends</string>
+    <string name="game_2">Heroes of the Storm</string>
+    <string name="game_3">Vainglory</string>
+    <string name="game_4">Smite</string>
+    <string name="game_5">Dota 2</string>
+
+    <!-- Topic Names -->
+    <string name="topic_1">Patch Notes</string>
+    <string name="topic_2">Game Updates</string>
+    <string name="topic_3">Cosmetics</string>
+    <string name="topic_4">Game Modes</string>
+
+    <!-- Fallback for unknown games/topics -->
+    <string name="unknown_game">Unknown Game</string>
+    <string name="unknown_topic">Unknown Topic</string>
 </resources>


### PR DESCRIPTION
Created an enum data type in Supabase.
Map the enum to our code enum.
Added a way to map code enum to string resource (in case we want to display it somewhere.)

Enum Data Type:
<img width="1060" height="381" alt="image" src="https://github.com/user-attachments/assets/46d170d7-c771-4697-a4bd-22655ef1ab05" />

Table Data: using enum type:
<img width="573" height="474" alt="image" src="https://github.com/user-attachments/assets/09bdd51c-3cf4-4f68-adfd-40ac7bf3a279" />

TopicEnum.kt handles serialization.

ResourceMappter.kt handles taking the game id, topic enum and mapping them to localized strings from the strings.xml.  I do not know if we plan to show the topic names or game names anywhere, but we don't currently. However they are there now if needed.
