### PR TITLE
Browse screen button functionality

### DIFF
--- a/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
@@ -88,7 +88,7 @@ private fun TopAppBarPR(
                             text = stringResource(R.string.feed),
                             onClick = { navigationViewModel.navigateToMainTab(AppRoutes.HOME_FEED) },
                             modifier.padding(8.dp),
-                            selected = currentRoute == AppRoutes.HOME_FEED
+                            selected = currentRoute.startsWith(AppRoutes.HOME_FEED) == true
                         )
                         TopAppBarButtonPR(
                             text = stringResource(R.string.all),
@@ -201,7 +201,21 @@ fun HomeScreen(
                 AllTabContent(navigationViewModel, articleListViewModel)
             }
             composable(route = AppRoutes.HOME_BROWSE) {
-                BrowseScreen()
+                BrowseScreen(navigationViewModel)
+            }
+            composable(
+                route = "feed/{topic}",
+                arguments = listOf(
+                    navArgument("topic") {
+                        type = NavType.StringType
+                    }
+                )
+            ) { backStackEntry ->
+                val topic = backStackEntry.arguments?.getString("topic")
+                FeedScreen(
+                    navigationViewModel = navigationViewModel,
+                    filters = listOf(topic)
+                )
             }
             composable(route = AppRoutes.SETTINGS_EDIT_ACCOUNT) {
                 EditAccountScreen()

--- a/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
@@ -100,7 +100,7 @@ private fun TopAppBarPR(
                             text = stringResource(R.string.browse),
                             onClick = { navigationViewModel.navigateToMainTab(AppRoutes.HOME_BROWSE) },
                             modifier.padding(8.dp),
-                            selected = currentRoute == AppRoutes.HOME_BROWSE
+                            selected = currentRoute.startsWith(AppRoutes.HOME_BROWSE) == true
                         )
                     }
 
@@ -204,7 +204,7 @@ fun HomeScreen(
                 BrowseScreen(navigationViewModel)
             }
             composable(
-                route = "feed/{topic}",
+                route = "browse/{topic}",
                 arguments = listOf(
                     navArgument("topic") {
                         type = NavType.StringType

--- a/src/client/app/src/main/java/com/example/ravengamingnews/navigation/AppRoutes.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/navigation/AppRoutes.kt
@@ -5,6 +5,7 @@ import com.example.ravengamingnews.R
 object AppRoutes {
     // Home section routes
     const val HOME_FEED = "feed"
+    const val HOME_FEED_TOPIC = "feed/{topic}"
     const val HOME_BROWSE = "browse"
     const val HOME_ALL = "all"
     const val ARTICLE_DETAILS = "article/{articleId}"

--- a/src/client/app/src/main/java/com/example/ravengamingnews/navigation/AppRoutes.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/navigation/AppRoutes.kt
@@ -5,7 +5,6 @@ import com.example.ravengamingnews.R
 object AppRoutes {
     // Home section routes
     const val HOME_FEED = "feed"
-    const val HOME_FEED_TOPIC = "feed/{topic}"
     const val HOME_BROWSE = "browse"
     const val HOME_ALL = "all"
     const val ARTICLE_DETAILS = "article/{articleId}"

--- a/src/client/app/src/main/java/com/example/ravengamingnews/navigation/NavigationViewModel.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/navigation/NavigationViewModel.kt
@@ -48,4 +48,13 @@ class NavigationViewModel @Inject constructor() : ViewModel() {
     fun popBackStack() {
         _navController?.popBackStack()
     }
+
+    fun navigateToFeed(topic: String) {
+        _navController?.let { navController ->
+            navController.popBackStack(route = AppRoutes.HOME_BROWSE, inclusive = false)
+            navController.navigate("feed/$topic") {
+                launchSingleTop = true
+            }
+        }
+    }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreen.kt
@@ -123,8 +123,8 @@ fun CategoryGroupPR(
             items(categories) { category ->
                 CategoryButtonPR(
                     onClick = {
-                        navigationViewModel.navigateToFeed(
-                            category.title
+                        navigationViewModel.navigateTo(
+                            "browse/${category.title}"
                         )
                     },
                     category = category

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.ravengamingnews.navigation.NavigationViewModel
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
 
 val colorStops = arrayOf(
@@ -88,6 +90,7 @@ fun CategoryGroupPR(
     title: String,
     categories: List<Category>,
     modifier: Modifier = Modifier,
+    navigationViewModel: NavigationViewModel,
 ) {
     Column (
         modifier = modifier
@@ -119,7 +122,11 @@ fun CategoryGroupPR(
         ) {
             items(categories) { category ->
                 CategoryButtonPR(
-                    onClick = { },
+                    onClick = {
+                        navigationViewModel.navigateToFeed(
+                            category.title
+                        )
+                    },
                     category = category
                 )
             }
@@ -160,11 +167,13 @@ fun CategoryButtonPreview() {
             ) {
                 CategoryGroupPR(
                     title = "Test Category",
-                    categories = getTestCategories()
+                    categories = getTestCategories(),
+                    navigationViewModel = hiltViewModel()
                 )
                 CategoryGroupPR(
                     title = "Test Category 2",
-                    categories = getTestCategories()
+                    categories = getTestCategories(),
+                    navigationViewModel = hiltViewModel()
                 )
             }
         }
@@ -187,6 +196,10 @@ private fun getGamesCategories() : List<Category> {
         ),
         Category(
             title = "Fortnite",
+            image = null
+        ),
+        Category(
+            title = "Dota 2",
             image = null
         ),
     )
@@ -244,11 +257,9 @@ private fun getContentCategories(): List<Category> {
 
 @Composable
 fun BrowseScreen(
-    modifier: Modifier = Modifier,
+    navigationViewModel: NavigationViewModel = hiltViewModel(),
 ) {
-    Scaffold(
-        modifier = modifier
-    ) { innerPadding ->
+    Scaffold{ innerPadding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
@@ -258,19 +269,22 @@ fun BrowseScreen(
             item {
                 CategoryGroupPR(
                     title = "Games",
-                    categories = getGamesCategories()
+                    categories = getGamesCategories(),
+                    navigationViewModel = navigationViewModel
                 )
             }
             item {
                 CategoryGroupPR(
                     title = "Platforms",
-                    categories = getPlatformCategories()
+                    categories = getPlatformCategories(),
+                    navigationViewModel = navigationViewModel
                 )
             }
             item {
                 CategoryGroupPR(
                     title = "Content",
-                    categories = getContentCategories()
+                    categories = getContentCategories(),
+                    navigationViewModel = navigationViewModel
                 )
             }
         }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreen.kt
@@ -233,7 +233,11 @@ private fun getContentCategories(): List<Category> {
             image = null
         ),
         Category(
-            title = "Patch Notes/Updates",
+            title = "Patch Notes",
+            image = null
+        ),
+        Category(
+            title = "Updates",
             image = null
         ),
         Category(
@@ -245,7 +249,11 @@ private fun getContentCategories(): List<Category> {
             image = null
         ),
         Category(
-            title = "Game Guides/Tutorials",
+            title = "Game Guides",
+            image = null
+        ),
+        Category(
+            title = "Tutorials",
             image = null
         ),
         Category(

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/FeedScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/FeedScreen.kt
@@ -25,11 +25,22 @@ import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
 fun FeedScreen(
     navigationViewModel: NavigationViewModel = hiltViewModel(),
     articlesViewModel: ArticleListViewModel = hiltViewModel(),
+    filters: List<String?>? = null,
+    sort: String? = null
 ) {
     val articleList =
         articlesViewModel.articleList.collectAsState(initial = listOf()).value
     val clickedArticles by articlesViewModel.clickedArticles.collectAsState(initial = emptyMap())
     val isRefreshing = articlesViewModel.isRefreshing.collectAsState(false).value
+
+    val filteredArticles = filters?.let { filterList ->
+        articleList.filter { article ->
+            filterList.any { filter ->
+                filter?.let { article.title.contains(it) } ?: false
+            }
+        }
+    } ?: articleList
+
     PullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = { articlesViewModel.getArticles() },
@@ -53,7 +64,7 @@ fun FeedScreen(
                     )
                 }
             }
-            items(items = articleList) { item ->
+            items(items = filteredArticles) { item ->
                 val isClicked = clickedArticles[item.id] == true
                 ArticleCard(
                     item.title,


### PR DESCRIPTION
Added button functionality. Adds sorting functionality in the future if we want a way to sort by something like date, popular, newest(probably default).

Added routing for browse to feed and updated selected requirements for feed button on the nav bar.

#ISSUE I COULD NOT RESOLVE
When you press a filter from the browse screen and try to navigate to the browse screen via nav bar button, it has loaded the feed screen with the filter. This means to navigate back it HAS to be done with the undo button from the device(either swipe right or backwards arrow button on dock). Not a necessity to fix as functionality is still there but worth noting its a quirk with the state I could not figure out. When backing out via undo button you can reselect a new filter and the feed screen will populate as expected with a new filter. 