### PR TITLE
Loading vs. Refreshing

### DIFF
--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/AllTabContent.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/AllTabContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -13,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,6 +33,7 @@ fun AllTabContent(
         articlesViewModel.articleList.collectAsState(initial = listOf()).value
     val clickedArticles by articlesViewModel.clickedArticles.collectAsState(initial = emptyMap())
     val isRefreshing = articlesViewModel.isRefreshing.collectAsState(false).value
+    val isLoading = articlesViewModel.isLoading.collectAsState(false).value
 
     LaunchedEffect(Unit) {
         articlesViewModel.getArticles()
@@ -38,9 +41,18 @@ fun AllTabContent(
 
     PullToRefreshBox(
         isRefreshing = isRefreshing,
-        onRefresh = { articlesViewModel.getArticles() },
+        onRefresh = { articlesViewModel.refreshArticles() },
         modifier = Modifier.fillMaxSize()
     ) {
+
+        if (isLoading) {
+            LinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+            )
+        }
+
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticleListViewModel.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticleListViewModel.kt
@@ -27,6 +27,9 @@ class ArticleListViewModel @Inject constructor(
     private val _articles = MutableStateFlow<List<Article>>(listOf())
     val articleList: Flow<List<Article>> = _articles
 
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing
 
@@ -34,23 +37,37 @@ class ArticleListViewModel @Inject constructor(
     val browseFilter: Flow<Filter?> = _browseFilter
 
     init {
+        _isLoading.value = true
+        _isRefreshing.value = false
         getArticles()
     }
 
     fun getArticles() {
+        _isLoading.value = true
+        _isRefreshing.value = false
+        getArticlesAll()
+    }
+
+    fun refreshArticles() {
+        _isLoading.value = false
+        _isRefreshing.value = true
+        getArticlesAll()
+    }
+
+    private fun getArticlesAll() {
         viewModelScope.launch {
-            _isRefreshing.value = true
             when (val result = getArticlesUseCase.execute(input = Unit)) {
                 is GetArticlesUseCase.Output.Success -> {
                     _articles.emit(result.articles)
-                    _isRefreshing.value = false
                 }
 
                 is GetArticlesUseCase.Output.Failure -> {
                     Log.e(LOG_TAG, "Error fetching articles")
-                    _isRefreshing.value = false
                 }
             }
+            kotlinx.coroutines.delay(800)
+            _isLoading.value = false
+            _isRefreshing.value = false
         }
     }
 
@@ -63,6 +80,16 @@ class ArticleListViewModel @Inject constructor(
     }
 
     fun getArticlesByFilters(gameFilter: List<GameFilter>, topicFilter: List<TopicFilter>) {
+        _isLoading.value = true
+        getWithFilters(gameFilter, topicFilter)
+    }
+
+    fun refreshArticlesByFilters(gameFilter: List<GameFilter>, topicFilter: List<TopicFilter>) {
+        _isRefreshing.value = true
+        getWithFilters(gameFilter, topicFilter)
+    }
+
+    private fun getWithFilters(gameFilter: List<GameFilter>, topicFilter: List<TopicFilter>) {
         val selectedGames = gameFilter.filter { it.isChecked }.map { it.gameId }
         val selectedTopics = topicFilter.filter { it.isChecked }.map { it.topicEnum }
         if (selectedGames.isEmpty() && selectedTopics.isEmpty()) {
@@ -70,28 +97,37 @@ class ArticleListViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
-            _isRefreshing.value = true
             when (val result = getArticlesUseCase.execute(input = Unit)) {
                 is GetArticlesUseCase.Output.Success -> {
                     _articles.emit(result.articles.filter { article ->
                         (selectedGames.isEmpty() || selectedGames.contains(article.gameId)) &&
                                 (selectedTopics.isEmpty() || selectedTopics.contains(article.topic))
                     })
-                    _isRefreshing.value = false
                 }
 
                 is GetArticlesUseCase.Output.Failure -> {
                     Log.e(LOG_TAG, "Error fetching articles by filters")
-                    _isRefreshing.value = false
                 }
             }
+            kotlinx.coroutines.delay(800)
+            _isLoading.value = false
+            _isRefreshing.value = false
         }
     }
 
     fun getArticlesByFilter(filter: Filter) {
+        _isLoading.value = true
+        getWithFilter(filter)
+    }
+
+    fun refreshArticlesByFilter(filter: Filter) {
+        _isRefreshing.value = true
+        getWithFilter(filter)
+    }
+
+    private fun getWithFilter(filter: Filter) {
         _browseFilter.value = filter
         viewModelScope.launch {
-            _isRefreshing.value = true
             when (val result = getArticlesUseCase.execute(input = Unit)) {
                 is GetArticlesUseCase.Output.Success -> {
                     _articles.emit(result.articles.filter { article ->
@@ -101,14 +137,15 @@ class ArticleListViewModel @Inject constructor(
                             else -> false
                         }
                     })
-                    _isRefreshing.value = false
                 }
 
                 is GetArticlesUseCase.Output.Failure -> {
                     Log.e(LOG_TAG, "Error fetching articles by filter")
-                    _isRefreshing.value = false
                 }
             }
+            kotlinx.coroutines.delay(800)
+            _isLoading.value = false
+            _isRefreshing.value = false
         }
     }
 

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreenAlt.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreenAlt.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -46,7 +47,6 @@ fun BrowseScreenAlt(
     val games = filtersViewModel.gameFilters.collectAsState().value
     val topics = filtersViewModel.topicFilters.collectAsState().value
     val browseFilter = articleListViewModel.browseFilter.collectAsState(null).value
-
 
     LaunchedEffect(Unit) {
         filtersViewModel.loadUserFilters()
@@ -100,9 +100,11 @@ fun BrowseScreenAlt(
         val isRefreshing = articleListViewModel.isRefreshing.collectAsState(false).value
         val articleList = articleListViewModel.articleList.collectAsState(initial = listOf()).value
         val clickedArticles by articleListViewModel.clickedArticles.collectAsState(initial = emptyMap())
+        val isLoading = articleListViewModel.isLoading.collectAsState(false).value
         ArticleList(
+            isLoading = isLoading,
             isRefreshing = isRefreshing,
-            onRefresh = { articleListViewModel.getArticlesByFilter(browseFilter) },
+            onRefresh = { articleListViewModel.refreshArticlesByFilter(browseFilter) },
             articleList = articleList,
             clickedArticles = clickedArticles,
             onClicked = { article ->
@@ -186,12 +188,20 @@ private fun ArticleList(
     articleList: List<Article>,
     clickedArticles: Map<Int, Boolean>,
     isRefreshing: Boolean,
+    isLoading: Boolean
 ) {
     PullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = onRefresh,
         modifier = modifier.fillMaxSize()
     ) {
+        if (isLoading) {
+            LinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+            )
+        }
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/FeedScreenAlt.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/FeedScreenAlt.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -13,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -32,6 +34,7 @@ fun FeedScreenAlt(
         articlesViewModel.articleList.collectAsState(initial = listOf()).value
     val clickedArticles by articlesViewModel.clickedArticles.collectAsState(initial = emptyMap())
     val isRefreshing = articlesViewModel.isRefreshing.collectAsState(false).value
+    val isLoading = articlesViewModel.isLoading.collectAsState(false).value
 
     LaunchedEffect(Unit) {
         filtersViewModel.loadUserFilters()
@@ -45,9 +48,18 @@ fun FeedScreenAlt(
 
     PullToRefreshBox(
         isRefreshing = isRefreshing,
-        onRefresh = { articlesViewModel.getArticlesByFilters(gameFilters, topicFilters) },
+        onRefresh = { articlesViewModel.refreshArticlesByFilters(gameFilters, topicFilters) },
         modifier = Modifier.fillMaxSize()
     ) {
+
+        if (isLoading) {
+            LinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+            )
+        }
+
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()


### PR DESCRIPTION
Fixing the issue with loading vs. refreshing.  Before every screen would flash the pull-down to refresh indicator, as there was only one state.

The ArticlesListViewModel now has separate loading vs. refreshing states.  There is now a separate method to use when loading and a separate method to use when refreshing.  That sets the appropriate state.  Then, when the API call finishes, both states are reset to false.

### Video Demo
https://streamable.com/1tnjgv
