### PR TITLE
Lock Orientation

### DIFF
--- a/src/client/app/src/main/AndroidManifest.xml
+++ b/src/client/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/Theme.RavenGamingNews">
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
             android:exported="true"
             android:theme="@style/Theme.RavenGamingNews">
             <intent-filter>


### PR DESCRIPTION
Simple line of text addition to manifest.

<img width="555" height="519" alt="image" src="https://github.com/user-attachments/assets/4002ae5f-46db-4fd7-8ab5-968a84a9c3fc" />

Dont know why it looks like an error. It works, context actions just seems to say it's a discouraged action.

<img width="652" height="333" alt="image" src="https://github.com/user-attachments/assets/b8bc4061-9b7a-4714-a08a-a727c89becab" />
