### PR TITLE
Fix tab selection

### DIFF
--- a/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
@@ -161,7 +161,6 @@ fun HomeScreen(
 ) {
     val navController = rememberNavController()
     val navigationViewModel: NavigationViewModel = hiltViewModel()
-    val articleListViewModel: ArticleListViewModel = hiltViewModel()
     val editAccountViewModel: EditAccountViewModel = hiltViewModel()
     val filtersViewModel: FiltersViewModel = hiltViewModel()
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -202,18 +201,16 @@ fun HomeScreen(
 //                FeedScreen(navigationViewModel, articleListViewModel)
                 FeedScreenAlt(
                     navigationViewModel = navigationViewModel,
-                    articlesViewModel = articleListViewModel,
                     filtersViewModel = filtersViewModel
                 )
             }
             composable(route = AppRoutes.HOME_ALL) {
-                AllTabContent(navigationViewModel, articleListViewModel)
+                AllTabContent(navigationViewModel)
             }
             composable(route = AppRoutes.HOME_BROWSE) {
 //                BrowseScreen()
                 BrowseScreenAlt(
                     filtersViewModel = filtersViewModel,
-                    articleListViewModel = articleListViewModel,
                     navigationViewModel = navigationViewModel
                 )
             }
@@ -244,7 +241,7 @@ fun HomeScreen(
                 })
             ) { backStackEntry ->
                 val articleId = backStackEntry.arguments?.getString("articleId")
-                ArticlePage(articleId = articleId, articleListViewModel)
+                ArticlePage(articleId = articleId)
             }
         }
     }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults.mediumTopAppBarColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -61,9 +62,7 @@ private fun TopAppBarPR(
     navigationViewModel: NavigationViewModel = hiltViewModel(),
     navController: androidx.navigation.NavHostController
 ) {
-    val backStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = backStackEntry?.destination?.route ?: AppRoutes.HOME_FEED
-
+    val currentRoute = navigationViewModel.currentRoute.collectAsState("").value
     val scope = rememberCoroutineScope()
 
     Surface(shadowElevation = 16.dp) {

--- a/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/HomeScreen.kt
@@ -41,18 +41,17 @@ import com.example.ravengamingnews.navigation.NavigationViewModel
 import com.example.ravengamingnews.ui.AboutScreen
 import com.example.ravengamingnews.ui.AllTabContent
 import com.example.ravengamingnews.ui.ArticlePage
+import com.example.ravengamingnews.ui.BrowseScreenAlt
 import com.example.ravengamingnews.ui.EditAccountScreen
+import com.example.ravengamingnews.ui.EditAccountViewModel
+import com.example.ravengamingnews.ui.FeedScreenAlt
+import com.example.ravengamingnews.ui.FiltersScreenAlt
+import com.example.ravengamingnews.ui.FiltersViewModel
 import com.example.ravengamingnews.ui.SavedScreen
 import com.example.ravengamingnews.ui.SupportScreen
 import com.example.ravengamingnews.ui.components.LogoImagePR
 import com.example.ravengamingnews.ui.components.TopAppBarButtonPR
 import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
-import com.example.ravengamingnews.ui.ArticleListViewModel
-import com.example.ravengamingnews.ui.BrowseScreenAlt
-import com.example.ravengamingnews.ui.EditAccountViewModel
-import com.example.ravengamingnews.ui.FeedScreenAlt
-import com.example.ravengamingnews.ui.FiltersScreenAlt
-import com.example.ravengamingnews.ui.FiltersViewModel
 import kotlinx.coroutines.launch
 
 @Composable
@@ -184,24 +183,19 @@ fun HomeScreen(
                 SettingsTopAppBar(
                     title = stringResource(
                         AppRoutes.getTitleResId(currentRoute)
-                    ),
-                    onBackClicked = { navigationViewModel.navigateUp() }
-                )
+                    ), onBackClicked = { navigationViewModel.navigateUp() })
             }
-        }
-    ) { innerPadding ->
+        }) { innerPadding ->
         NavHost(
             navController = navController,
             startDestination = AppRoutes.HOME_FEED,
             modifier = Modifier.padding(innerPadding),
             enterTransition = { fadeIn(animationSpec = tween(500)) },
-            exitTransition = { fadeOut(animationSpec = tween(500)) }
-        ) {
+            exitTransition = { fadeOut(animationSpec = tween(500)) }) {
             composable(route = AppRoutes.HOME_FEED) {
 //                FeedScreen(navigationViewModel, articleListViewModel)
                 FeedScreenAlt(
-                    navigationViewModel = navigationViewModel,
-                    filtersViewModel = filtersViewModel
+                    navigationViewModel = navigationViewModel, filtersViewModel = filtersViewModel
                 )
             }
             composable(route = AppRoutes.HOME_ALL) {
@@ -210,8 +204,7 @@ fun HomeScreen(
             composable(route = AppRoutes.HOME_BROWSE) {
 //                BrowseScreen()
                 BrowseScreenAlt(
-                    filtersViewModel = filtersViewModel,
-                    navigationViewModel = navigationViewModel
+                    filtersViewModel = filtersViewModel, navigationViewModel = navigationViewModel
                 )
             }
             composable(route = AppRoutes.SETTINGS_EDIT_ACCOUNT) {
@@ -222,10 +215,7 @@ fun HomeScreen(
                 FiltersScreenAlt(viewModel = filtersViewModel)
             }
             composable(route = AppRoutes.SETTINGS_SAVED) {
-                SavedScreen(
-                    navigationViewModel = navigationViewModel,
-                    articlesViewModel = articleListViewModel
-                )
+                SavedScreen(navigationViewModel = navigationViewModel)
             }
             composable(route = AppRoutes.SETTINGS_SUPPORT) {
                 SupportScreen()
@@ -234,10 +224,8 @@ fun HomeScreen(
                 AboutScreen()
             }
             composable(
-                route = AppRoutes.ARTICLE_DETAILS,
-                arguments = listOf(navArgument("articleId") {
-                    type =
-                        NavType.StringType
+                route = AppRoutes.ARTICLE_DETAILS, arguments = listOf(navArgument("articleId") {
+                    type = NavType.StringType
                 })
             ) { backStackEntry ->
                 val articleId = backStackEntry.arguments?.getString("articleId")
@@ -252,9 +240,7 @@ fun HomeScreen(
 fun SettingsTopAppBarPreview() {
     RavenGamingNewsTheme {
         SettingsTopAppBar(
-            title = stringResource(R.string.account),
-            onBackClicked = {}
-        )
+            title = stringResource(R.string.account), onBackClicked = {})
     }
 }
 

--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/local/UserPreferencesRepository.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/local/UserPreferencesRepository.kt
@@ -6,4 +6,7 @@ interface UserPreferencesRepository {
 
     suspend fun saveGuestFilters(filters: UserFilters)
     suspend fun getGuestFilters(): UserFilters?
+    suspend fun savedArticles(): Set<Int>
+    suspend fun saveArticle(articleId: Int): Set<Int>
+    suspend fun removeArticle(articleId: Int): Set<Int>
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/local/impl/UserPreferencesRepositoryImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/local/impl/UserPreferencesRepositoryImpl.kt
@@ -23,6 +23,7 @@ class UserPreferencesImpl @Inject constructor(
     companion object {
         private const val PREFS_NAME = "raven_gaming_prefs"
         private const val KEY_GUEST_FILTERS = "guest_user_filters"
+        private const val KEY_SAVED_ARTICLES = "saved_articles"
     }
 
     private val masterKey = MasterKey.Builder(context)
@@ -52,5 +53,24 @@ class UserPreferencesImpl @Inject constructor(
             Log.e(LOG_TAG, "Error decoding guest filters: ${e.message}")
             null
         }
+    }
+
+    override suspend fun savedArticles(): Set<Int> {
+        val articles = prefs.getStringSet(KEY_SAVED_ARTICLES, emptySet()) ?: emptySet()
+        return articles.mapNotNull { it.toIntOrNull() }.toSet()
+    }
+
+    override suspend fun saveArticle(articleId: Int): Set<Int> {
+        val currentArticles = prefs.getStringSet(KEY_SAVED_ARTICLES, emptySet()) ?: emptySet()
+        val updatedArticles = currentArticles.toMutableSet().apply { add(articleId.toString()) }
+        prefs.edit { putStringSet(KEY_SAVED_ARTICLES, updatedArticles) }
+        return updatedArticles.mapNotNull { it.toIntOrNull() }.toSet()
+    }
+
+    override suspend fun removeArticle(articleId: Int): Set<Int> {
+        val currentArticles = prefs.getStringSet(KEY_SAVED_ARTICLES, emptySet()) ?: emptySet()
+        val updatedArticles = currentArticles.toMutableSet().apply { remove(articleId.toString()) }
+        prefs.edit { putStringSet(KEY_SAVED_ARTICLES, updatedArticles) }
+        return updatedArticles.mapNotNull { it.toIntOrNull() }.toSet()
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/data/repository/impl/ArticleRepositoryImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/data/repository/impl/ArticleRepositoryImpl.kt
@@ -10,12 +10,11 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ArticleRepositoryImpl @Inject constructor(
-    private val postgrest: Postgrest
+    private val postgrest: Postgrest,
 ) : ArticleRepository {
     override suspend fun getArticles(): List<ArticleDto>? {
         return withContext(Dispatchers.IO) {
-            val result = postgrest.from("articles")
-                .select(
+            val result = postgrest.from("articles").select(
                     Columns.raw(
                         """
                             *,
@@ -28,8 +27,7 @@ class ArticleRepositoryImpl @Inject constructor(
                     )
                 ) {
                     order("date", Order.DESCENDING)
-                }
-                .decodeList<ArticleDto>()
+                }.decodeList<ArticleDto>()
             result
         }
     }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/di/UseCaseModule.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/di/UseCaseModule.kt
@@ -31,4 +31,12 @@ abstract class UseCaseModule {
     @Binds
     abstract fun bindUpdateUserFiltersUseCase(impl: UpdateUserFiltersUseCaseImpl): UpdateUserFiltersUseCase
 
+    @Binds
+    abstract fun bindSaveArticleUseCase(impl: SaveArticleUseCaseImpl): SaveArticleUseCase
+
+    @Binds
+    abstract fun bindRemoveArticleUseCase(impl: RemoveSavedArticleUseCaseImpl): RemoveSavedArticleUseCase
+
+    @Binds
+    abstract fun bindGetSavedArticlesUseCase(impl: GetSavedArticlesUseCaseImpl): GetSavedArticlesUseCase
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/GetSavedArticlesUseCase.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/GetSavedArticlesUseCase.kt
@@ -1,0 +1,8 @@
+package com.example.ravengamingnews.domain.usecase
+
+interface GetSavedArticlesUseCase : UseCase<Unit, GetSavedArticlesUseCase.Output> {
+    sealed class Output {
+        data class Success(val savedArticleIds: Set<Int>) : Output()
+        object Failure : Output()
+    }
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/RemoveSavedArticleUseCase.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/RemoveSavedArticleUseCase.kt
@@ -1,0 +1,8 @@
+package com.example.ravengamingnews.domain.usecase
+
+interface RemoveSavedArticleUseCase : UseCase<Int, RemoveSavedArticleUseCase.Output> {
+    sealed class Output {
+        data class Success(val savedArticles: Set<Int>) : Output()
+        object Failure : Output()
+    }
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/SaveArticleUseCase.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/SaveArticleUseCase.kt
@@ -1,0 +1,8 @@
+package com.example.ravengamingnews.domain.usecase
+
+interface SaveArticleUseCase : UseCase<Int, SaveArticleUseCase.Output> {
+    sealed class Output {
+        data class Success(val savedArticles: Set<Int>) : Output()
+        object Failure : Output()
+    }
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/GetSavedArticlesUseCaseImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/GetSavedArticlesUseCaseImpl.kt
@@ -1,0 +1,18 @@
+package com.example.ravengamingnews.domain.usecase.impl
+
+import com.example.ravengamingnews.data.local.UserPreferencesRepository
+import com.example.ravengamingnews.domain.usecase.GetSavedArticlesUseCase
+import javax.inject.Inject
+
+class GetSavedArticlesUseCaseImpl @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) : GetSavedArticlesUseCase {
+    override suspend fun execute(input: Unit): GetSavedArticlesUseCase.Output {
+        return try {
+            val savedArticles = userPreferencesRepository.savedArticles()
+            GetSavedArticlesUseCase.Output.Success(savedArticles)
+        } catch (e: Exception) {
+            GetSavedArticlesUseCase.Output.Failure
+        }
+    }
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/RemoveSavedArticleUseCaseImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/RemoveSavedArticleUseCaseImpl.kt
@@ -1,0 +1,18 @@
+package com.example.ravengamingnews.domain.usecase.impl
+
+import com.example.ravengamingnews.data.local.UserPreferencesRepository
+import com.example.ravengamingnews.domain.usecase.RemoveSavedArticleUseCase
+import javax.inject.Inject
+
+class RemoveSavedArticleUseCaseImpl @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository,
+) : RemoveSavedArticleUseCase {
+    override suspend fun execute(input: Int): RemoveSavedArticleUseCase.Output {
+        return try {
+            val savedArticles = userPreferencesRepository.removeArticle(input)
+            RemoveSavedArticleUseCase.Output.Success(savedArticles)
+        } catch (e: Exception) {
+            RemoveSavedArticleUseCase.Output.Failure
+        }
+    }
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/SaveArticleUseCaseImpl.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/domain/usecase/impl/SaveArticleUseCaseImpl.kt
@@ -1,0 +1,18 @@
+package com.example.ravengamingnews.domain.usecase.impl
+
+import com.example.ravengamingnews.data.local.UserPreferencesRepository
+import com.example.ravengamingnews.domain.usecase.SaveArticleUseCase
+import javax.inject.Inject
+
+class SaveArticleUseCaseImpl @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) : SaveArticleUseCase {
+    override suspend fun execute(input: Int): SaveArticleUseCase.Output {
+        return try {
+            val savedArticles = userPreferencesRepository.saveArticle(input)
+            SaveArticleUseCase.Output.Success(savedArticles)
+        } catch (e: Exception) {
+            SaveArticleUseCase.Output.Failure
+        }
+    }
+}

--- a/src/client/app/src/main/java/com/example/ravengamingnews/navigation/AppRoutes.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/navigation/AppRoutes.kt
@@ -20,6 +20,11 @@ object AppRoutes {
         return route.startsWith("settings/")
     }
 
+    fun isHomeRoute(route: String?): Boolean {
+        if (route == null) return false
+        return route == HOME_FEED || route == HOME_BROWSE || route == HOME_ALL
+    }
+
     fun getTitleResId(route: String): Int {
         return when (route) {
             SETTINGS_EDIT_ACCOUNT -> R.string.account

--- a/src/client/app/src/main/java/com/example/ravengamingnews/navigation/NavigationViewModel.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/navigation/NavigationViewModel.kt
@@ -3,6 +3,8 @@ package com.example.ravengamingnews.navigation
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
 /**
@@ -14,11 +16,22 @@ class NavigationViewModel @Inject constructor() : ViewModel() {
 
     private var _navController: NavController? = null
 
+    private val _currentRoute = MutableStateFlow<String?>(AppRoutes.HOME_FEED)
+    val currentRoute: Flow<String?> = _currentRoute
+
     fun setNavController(navController: NavController) {
         _navController = navController
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            if (destination.route != null && AppRoutes.isHomeRoute(destination.route)) {
+                _currentRoute.value = destination.route
+            }
+        }
     }
 
     fun navigateTo(route: String) {
+        if (route == _currentRoute.value) {
+            return
+        }
         _navController?.navigate(route)
     }
 
@@ -27,6 +40,9 @@ class NavigationViewModel @Inject constructor() : ViewModel() {
      * to ensure consistent tab selection behavior.
      */
     fun navigateToMainTab(route: String) {
+        if (route == _currentRoute.value) {
+            return
+        }
         _navController?.let { navController ->
             navController.navigate(route) {
                 // Pop up to the start destination to avoid building up a large stack

--- a/src/client/app/src/main/java/com/example/ravengamingnews/navigation/NavigationViewModel.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/navigation/NavigationViewModel.kt
@@ -1,11 +1,14 @@
 package com.example.ravengamingnews.navigation
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
+
+private const val LOG_TAG = "NavigationViewModel"
 
 /**
  * ViewModel to centralize navigation logic and reduce the need to pass NavController
@@ -23,7 +26,10 @@ class NavigationViewModel @Inject constructor() : ViewModel() {
         _navController = navController
         navController.addOnDestinationChangedListener { _, destination, _ ->
             if (destination.route != null && AppRoutes.isHomeRoute(destination.route)) {
+                Log.d(LOG_TAG, "Navigated to ${destination.route}")
                 _currentRoute.value = destination.route
+            } else {
+                Log.d(LOG_TAG, "Destination route is ${destination.route}, not updating currentRoute")
             }
         }
     }
@@ -40,9 +46,8 @@ class NavigationViewModel @Inject constructor() : ViewModel() {
      * to ensure consistent tab selection behavior.
      */
     fun navigateToMainTab(route: String) {
-        if (route == _currentRoute.value) {
-            return
-        }
+        Log.d(LOG_TAG, "Navigating to main tab: $route")
+        _currentRoute.value = route
         _navController?.let { navController ->
             navController.navigate(route) {
                 // Pop up to the start destination to avoid building up a large stack

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticleListViewModel.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticleListViewModel.kt
@@ -8,10 +8,14 @@ import com.example.ravengamingnews.data.GameFilter
 import com.example.ravengamingnews.data.TopicFilter
 import com.example.ravengamingnews.domain.model.Article
 import com.example.ravengamingnews.domain.usecase.GetArticlesUseCase
+import com.example.ravengamingnews.domain.usecase.GetSavedArticlesUseCase
+import com.example.ravengamingnews.domain.usecase.RemoveSavedArticleUseCase
+import com.example.ravengamingnews.domain.usecase.SaveArticleUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,10 +24,12 @@ private const val LOG_TAG = "ArticleListViewModel"
 @HiltViewModel
 class ArticleListViewModel @Inject constructor(
     private val getArticlesUseCase: GetArticlesUseCase,
-
+    private val getSavedArticlesUseCase: GetSavedArticlesUseCase,
+    private val saveArticleUseCase: SaveArticleUseCase,
+    private val removeSavedArticleUseCase: RemoveSavedArticleUseCase
 ) : ViewModel() {
 
-    private val _savedArticles: MutableStateFlow<Set<Int>> = MutableStateFlow<Set<Int>>(emptySet())
+    private val _savedArticles: MutableStateFlow<Set<Int>> = MutableStateFlow(emptySet())
     val savedArticles: Flow<Set<Int>> = _savedArticles
     private val _clickedArticles = MutableStateFlow<Map<Int, Boolean>>(emptyMap())
     val clickedArticles: Flow<Map<Int, Boolean>> = _clickedArticles
@@ -44,6 +50,7 @@ class ArticleListViewModel @Inject constructor(
         _isLoading.value = true
         _isRefreshing.value = false
         getArticles()
+        loadSavedArticles()
     }
 
     fun getArticles() {
@@ -77,10 +84,6 @@ class ArticleListViewModel @Inject constructor(
 
     fun clearFilters() {
         _browseFilter.value = null
-    }
-
-    fun getArticleById(id: Int): Article? {
-        return _articles.value.find { it.id == id }
     }
 
     fun getArticlesByFilters(gameFilter: List<GameFilter>, topicFilter: List<TopicFilter>) {
@@ -158,15 +161,52 @@ class ArticleListViewModel @Inject constructor(
     }
 
     fun toggleSaveArticle(articleId: Int) {
-        val current = _savedArticles.value
-        _savedArticles.value = if (current.contains(articleId)) {
-            current - articleId
+        if (_savedArticles.value.contains(articleId)) {
+            removeSavedArticle(articleId)
         } else {
-            current + articleId
+            saveArticle(articleId)
         }
     }
 
-    fun getSavedArticles(): List<Article> {
-        return _articles.value?.filter {_savedArticles.value.contains(it.id) } ?: emptyList()
+    fun loadSavedArticles() {
+        viewModelScope.launch {
+            when (val result = getSavedArticlesUseCase.execute(input = Unit)) {
+                is GetSavedArticlesUseCase.Output.Success -> {
+                    _savedArticles.emit(result.savedArticleIds)
+                }
+
+                is GetSavedArticlesUseCase.Output.Failure -> {
+                    Log.e(LOG_TAG, "Error fetching saved articles")
+                }
+            }
+        }
+    }
+
+    private fun saveArticle(articleId: Int) {
+        viewModelScope.launch {
+            when (val result = saveArticleUseCase.execute(input = articleId)) {
+                is SaveArticleUseCase.Output.Success -> {
+                    _savedArticles.emit(result.savedArticles)
+                }
+
+                is SaveArticleUseCase.Output.Failure -> {
+                    Log.e(LOG_TAG, "Error saving article")
+                }
+            }
+        }
+    }
+
+    private fun removeSavedArticle(articleId: Int) {
+        viewModelScope.launch {
+            when (val result = removeSavedArticleUseCase.execute(input = articleId)) {
+                is RemoveSavedArticleUseCase.Output.Success -> {
+                    _savedArticles.emit(result.savedArticles)
+                }
+
+                is RemoveSavedArticleUseCase.Output.Failure -> {
+                    Log.e(LOG_TAG, "Error removing saved article")
+                }
+            }
+        }
     }
 }

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticlePage.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/ArticlePage.kt
@@ -31,12 +31,9 @@ fun ArticlePage(
     articleId: String?,
     articleListViewModel: ArticleListViewModel = hiltViewModel(),
 ) {
+
     val id = articleId?.toIntOrNull()
-    val article = if (id != null) {
-        articleListViewModel.getArticleById(id)
-    } else {
-        null
-    }
+    val article = articleListViewModel.articleList.collectAsState(emptyList()).value.find { it.id == id }
 
     if (article == null) {
         Text("Article not found", modifier = Modifier.padding(8.dp))

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreenAlt.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/BrowseScreenAlt.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.ravengamingnews.data.Filter
 import com.example.ravengamingnews.domain.model.Article
 import com.example.ravengamingnews.navigation.AppRoutes
@@ -41,7 +42,7 @@ import com.example.ravengamingnews.ui.theme.RavenGamingNewsTheme
 fun BrowseScreenAlt(
     modifier: Modifier = Modifier,
     filtersViewModel: FiltersViewModel,
-    articleListViewModel: ArticleListViewModel,
+    articleListViewModel: ArticleListViewModel = hiltViewModel(),
     navigationViewModel: NavigationViewModel
 ) {
     val games = filtersViewModel.gameFilters.collectAsState().value

--- a/src/client/app/src/main/java/com/example/ravengamingnews/ui/SavedScreen.kt
+++ b/src/client/app/src/main/java/com/example/ravengamingnews/ui/SavedScreen.kt
@@ -11,11 +11,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 
 import com.example.ravengamingnews.navigation.AppRoutes
 import com.example.ravengamingnews.navigation.NavigationViewModel
@@ -27,14 +29,18 @@ import kotlin.time.Clock
 @Composable
 fun SavedScreen(
     navigationViewModel: NavigationViewModel,
-    articlesViewModel: ArticleListViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    articlesViewModel: ArticleListViewModel = hiltViewModel(),
 ) {
-    val savedArticles by articlesViewModel.savedArticles.collectAsState(initial = emptySet())
+
+    LaunchedEffect(Unit) {
+        articlesViewModel.loadSavedArticles()
+    }
+
     val articleList = articlesViewModel.articleList.collectAsState(initial = listOf()).value
     val clickedArticles by articlesViewModel.clickedArticles.collectAsState(initial = emptyMap())
-
-    val savedList = articleList?.filter {savedArticles.contains(it.id)} ?: emptyList()
+    val savedArticles by articlesViewModel.savedArticles.collectAsState(initial = emptySet())
+    val savedList = articleList.filter { savedArticles.contains(it.id) }
 
     if(savedList.isEmpty()){
         Column(


### PR DESCRIPTION
Added state tracking that only updates when changing top tabs.

You can see here, even on browse, when viewing a specific article, it remains highlighted:
<img width="343" height="385" alt="image" src="https://github.com/user-attachments/assets/b016facf-4ce4-4ce2-8ba1-93ed0d6cfdf8" />

All:

<img width="348" height="222" alt="image" src="https://github.com/user-attachments/assets/1b2807ac-4291-45e4-b16a-23f0ac620be8" />


Feed:
<img width="344" height="331" alt="image" src="https://github.com/user-attachments/assets/19dcf0f5-9147-4bdb-a380-3e54afaf9f23" />


I also fixed a major issue; if you are viewing an article and you switch tabs, it would get things completely out of whack.

~~There is still and issue with the tab higlighing during this situation but it is better than the original tab selection issue.~~
